### PR TITLE
Add sensu client address values as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Edit `/etc/sensu/conf.d/snmp_trap.json` to change its configuration.
 |result_attributes|hash|{}|Custom check result attributes to add to every SNMP trap Sensu check result|
 |result_map|array|[]|SNMP trap varbind to Sensu check result translation mappings|
 |result_status_map|array|[]|SNMP trap varbind to Sensu check result status mappings|
-|client_socket_bind|string|IP to send events to when handled|
-|client_socket_port|integer|Port to send events to when handled|
+|client_socket_bind|string|"127.0.0.1"|IP to send events to when handled|
+|client_socket_port|integer|3030|Port to send events to when handled|
 
 ### Result Map Examples
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Edit `/etc/sensu/conf.d/snmp_trap.json` to change its configuration.
     },
     "result_status_map": [
       ["authenticationFailure", 0]
-    ]
+    ],
+    "client_socket_bind": "192.168.0.3",
+    "client_socket_port": 1234
   }
 }
 ```
@@ -69,6 +71,8 @@ Edit `/etc/sensu/conf.d/snmp_trap.json` to change its configuration.
 |result_attributes|hash|{}|Custom check result attributes to add to every SNMP trap Sensu check result|
 |result_map|array|[]|SNMP trap varbind to Sensu check result translation mappings|
 |result_status_map|array|[]|SNMP trap varbind to Sensu check result status mappings|
+|client_socket_bind|string|IP to send events to when handled|
+|client_socket_port|integer|Port to send events to when handled|
 
 ### Result Map Examples
 

--- a/lib/sensu/extensions/snmp-trap.rb
+++ b/lib/sensu/extensions/snmp-trap.rb
@@ -58,7 +58,9 @@ module Sensu
           :handlers => ["default"],
           :result_attributes => {},
           :result_map => [],
-          :result_status_map => []
+          :result_status_map => [],
+          :client_socket_bind => "127.0.0.1",
+          :client_socket_port => 3030
         }
         @options.merge!(@settings[:snmp_trap]) if @settings[:snmp_trap].is_a?(Hash)
         @options
@@ -200,7 +202,7 @@ module Sensu
 
       def send_result(result)
         socket = UDPSocket.new
-        socket.send(Sensu::JSON.dump(result), 0, "127.0.0.1", 3030)
+        socket.send(Sensu::JSON.dump(result), 0, options[:client_socket_bind], options[:client_socket_port])
         socket.close
       end
 


### PR DESCRIPTION
Looks like the extension has the client IP and port hard-coded in the send_result function. This patch basically just does the same thing as the [snmptrap extension](https://github.com/warmfusion/sensu-extension-snmptrap) referred to in the README, by adding a :client_socket_ip and :client_socket_port option to define those values.

I defaulted to 127.0.0.1:3030 (as it was before) but it might be a good idea to pull client address from settings in the same way that the other extension did.